### PR TITLE
[18.0] stock_barcodes_picking_batch: finish v18 migration (compat with migrated stock_barcodes)

### DIFF
--- a/stock_barcodes_picking_batch/tests/test_stock_barcodes_picking_batch.py
+++ b/stock_barcodes_picking_batch/tests/test_stock_barcodes_picking_batch.py
@@ -108,8 +108,17 @@ class TestStockBarcodesPickingBatch(TestStockBarcodesPicking):
     def test_picking_batch_wizard_scan_product(self):
         self._create_quant_for_product(self.stock_location, self.product_wo_tracking)
         self.picking_batch.action_assign()
+        # The class-level wiz_scan_picking_batch was built in setUpClass BEFORE
+        # action_assign, so its cached pending moves do not reflect the freshly
+        # reserved sml. Re-build the wizard now (same pattern as the sibling
+        # test_picking_batch_wizard_scan_more_product_than_needed).
+        action = self.picking_batch.action_barcode_scan()
+        self.wiz_scan_picking_batch = self.ScanReadPicking.browse(action["res_id"])
+        # no_increase_qty_done makes each scan set qty_picked exactly to the
+        # scanned qty (1 by default) instead of accumulating to the move's
+        # full available_qty (a behaviour change in v18 vs v16).
         wiz_scan_picking_batch = self.wiz_scan_picking_batch.with_context(
-            force_create_move=True
+            force_create_move=True, no_increase_qty_done=True
         )
         self.action_barcode_scanned(wiz_scan_picking_batch, "8480000723208")
         sml = self.picking_batch.move_line_ids.filtered(
@@ -125,7 +134,7 @@ class TestStockBarcodesPickingBatch(TestStockBarcodesPicking):
         self.barcode_option_group_out.manual_entry = True
         self.barcode_option_group_out.is_manual_qty = True
         self.barcode_option_group_out.is_manual_confirm = True
-        self.barcode_option_group_out.show_pending_moves = True
+        self.barcode_option_group_out.show_pending_moves = "all"
 
         action = self.picking_batch.action_barcode_scan()
         self.wiz_scan_picking_batch = self.ScanReadPicking.browse(action["res_id"])

--- a/stock_barcodes_picking_batch/wizard/stock_barcodes_read_picking_batch.py
+++ b/stock_barcodes_picking_batch/wizard/stock_barcodes_read_picking_batch.py
@@ -35,20 +35,21 @@ class WizStockBarcodesReadPickingBatch(models.TransientModel):
         related="picking_batch_id.show_check_availability"
     )
 
-    def name_get(self):
-        if self.picking_mode != "picking_batch":
-            return super().name_get()
-        return [
-            (
-                rec.id,
-                "{} - {} - {}".format(
-                    _("Barcode reader"),
-                    rec.picking_batch_id.name or rec.picking_type_code,
-                    self.env.user.name,
-                ),
+    @api.depends("picking_batch_id", "picking_type_code", "picking_mode")
+    def _compute_display_name(self):
+        # v18: name_get was removed; display_name is computed. Keep the
+        # "Barcode reader - <batch/type> - <user>" label for batch wizards
+        # and delegate the rest to the base implementation.
+        batch_recs = self.filtered(lambda r: r.picking_mode == "picking_batch")
+        for rec in batch_recs:
+            rec.display_name = "{} - {} - {}".format(
+                _("Barcode reader"),
+                rec.picking_batch_id.name or rec.picking_type_code,
+                self.env.user.name,
             )
-            for rec in self
-        ]
+        other = self - batch_recs
+        if other:
+            super(WizStockBarcodesReadPickingBatch, other)._compute_display_name()
 
     def _compute_move_line_ids(self):
         if self.picking_mode != "picking_batch":
@@ -225,9 +226,13 @@ class WizStockBarcodesReadPickingBatch(models.TransientModel):
         return super().get_action_after_validate()
 
     def open_actions(self):
-        action = self.get_action_after_validate()
-        if action:
-            return action
+        # Only short-circuit to the post-validate redirect for batch wizards;
+        # otherwise fall through to the base open_actions, which sets
+        # display_menu (a plain picking wizard must still open the menu).
+        if self.picking_batch_id:
+            action = self.get_action_after_validate()
+            if action:
+                return action
         return super().open_actions()
 
     def _get_location_domain_for_quant_search(self):


### PR DESCRIPTION
Hi @sergio-teruel — fixes found testing #727 together with the migrated stock_barcodes (#725) downstream.

- name_get -> _compute_display_name (v18 removed name_get; display_name was wrong)
- open_actions: don't short-circuit base display_menu for non-batch wizards
- tests: show_pending_moves is a Selection now ("all"); rebuild the wizard after action_assign + no_increase_qty_done so qty_picked is set as in v18

With these, stock_barcodes (#725) + stock_barcodes_picking_batch (#727) is green (76/76) on 18.0.
